### PR TITLE
handle fetch errors on drop

### DIFF
--- a/samples/headless/core/line.js
+++ b/samples/headless/core/line.js
@@ -113,8 +113,8 @@ async function reference(site, slug, pid) {
 function probe(where, slug) {
   let site = where == null ? origin : where
   return fetch(`http://${site}/${slug}.json`)
-    .then(res => res.ok ? res.json() : null)
-    .catch(err => null)
+    .then(res => res.ok ? res.json() : ({title:'Error',story:[],journal:[],err:res.statusText||'unknown-1'}))
+    .catch(err => ({title:'Error',story:[],journal:[],err:res.message||'unknown-2'}))
 }
 
 function linkmark() {

--- a/samples/headless/core/test.js
+++ b/samples/headless/core/test.js
@@ -36,8 +36,13 @@ while(todo.length) {
 
   else if (pragma(/^► drop ([a-z-]+)@([a-zA-Z0-9\.]+)$/)) {
     await reference(m[2], m[1], lineup.slice(-1)[0].pid)
-    panes(1)
-    confirm(true)
+    let page = lineup.slice(-1)[0].page
+    if (!page.err) {
+      panes(1)
+      confirm(true)    
+    } else {
+      confirm(false, page.err)
+    }
   }
 
   else {


### PR DESCRIPTION
I suggested Pete add a second `► drop` to our First Functional Test. This failed win an inscrutable message which he documented.

![image](https://user-images.githubusercontent.com/12127/116835917-74913d00-ab79-11eb-9505-e0f9d69986a9.png)

I have revised the line.js implementation to construct a valid page even when fetch fails and to annotate that page with the error which can be detected by test.js and reported. 

![image](https://user-images.githubusercontent.com/12127/116835592-0304bf00-ab78-11eb-90ce-d6b431906404.png)

This correctly characterizes the failure and would suggest the remedy immediately.

I was once enthusiastic about reporting errors this way but am now less so when they are errors in the test setup. We will have more choices when we have more detailed events streaming both ways.