### PR TITLE
prefix "fail" inverts sense of test

### DIFF
--- a/samples/headless/core/line.js
+++ b/samples/headless/core/line.js
@@ -20,7 +20,7 @@ async function line() {
     let event = await next()
     switch (event.type) {
       case 'reload':
-        await reload(event.org, event.hash)
+        await reload(event.origin, event.hash)
         post({type:'reloaded'})
         break
       case 'reference':
@@ -35,12 +35,13 @@ async function line() {
   }
 }
 
-function reload(org, hash) {
-  origin = org
+function reload(origin, hash) {
   let fields = hash.replace(/(^[/#]+)|([/]+$)/g,'').split('/')
   let flight = []
   for (let field of fields) {
     let [slug,site] = field.split('@')
+    console.log({origin,hash,slug,site})
+    site ||= origin
     let panel = newpanel({site, slug, where:site})
     lineup.push(panel)
     flight.push(fetch(purl(site,slug)).then(res => res.json()).then(json => {panel.page = json; refresh(panel)}))

--- a/samples/headless/core/test.js
+++ b/samples/headless/core/test.js
@@ -29,10 +29,21 @@ panes(1)
 
 while(todo.length) {
 
-
   let m, next = todo.shift()
   const pragma = regex => { m = next.match(regex); return m }
   console.log(next)
+  let failed = false
+  next = next.replace(/^► fail /, () => {failed = true; return '► '})
+
+
+  function confirm(boolean, actual) {
+    let report = boolean != failed ?
+      Colors.green('succeeds') :
+      Colors.red('fails')
+    if (!boolean) report += ` with ${actual}`
+    console.log(report)
+  }
+
 
   if (pragma(/^► see (\d+) panels?$/)) {
     confirm(lineup.length == m[1], lineup.length)
@@ -75,12 +86,6 @@ function queue(page) {
       }
     }
   }
-}
-
-function confirm(boolean, actual) {
-  console.log(boolean ?
-    Colors.green('succeeds') :
-    Colors.red('fails') + ` with ${actual}`)
 }
 
 


### PR DESCRIPTION
Here an intentional incorrect spelling tests that errors are detected properly. Note "succeeds with Not Found".

![image](https://user-images.githubusercontent.com/12127/117559902-0992ab00-b03e-11eb-930b-61be34e998e5.png)
