### PR TITLE
click pragma refers to links which must exist in the lineup

### DIFF
--- a/samples/headless/core/test.js
+++ b/samples/headless/core/test.js
@@ -101,7 +101,7 @@ while(todo.length) {
     todo.splice(0,0,...pragmas(lineup.slice(-1)[0].page))
   }
 
-  else if (pragma(/^► click \[\[(.+?)\]\]$/)) {
+  else if (pragma(/^► click (.+?)$/)) {
     let title = m[1]
     let panel = lineup
       .filter(panel => panel.panes


### PR DESCRIPTION
The ► run pragma takes a [[ link ]] as its argument. This link is an honest reference to a page within the resolution context of the page it is on. The same is not true for clicks.

The ► click pragma takes title text as its argument. This will locate a link in the lineup and click that link in the resolution context within which it exists. 

This distinction makes it very confusing to have the click pragma argument rendered as a link that might not resolve without the lineup that proceedings pragmas construct. Here we change them to not be links in their own right.

![image](https://user-images.githubusercontent.com/12127/117917985-12ce8280-b29f-11eb-841b-60d0dfdfd3e6.png)

Notice that this commit title is longer than the code that provides the implementation.