### PR TITLE
queue multiple plugin loads for one import

### DIFF
--- a/samples/headless/core/test.js
+++ b/samples/headless/core/test.js
@@ -3,7 +3,7 @@
 
 let t0 = Date.now()
 
-import { lineup, types } from './line.js'
+import { lineup, plugins } from './line.js'
 import { post, open, register } from './stream.js'
 import * as Colors from '../vendor/colors.js'
 
@@ -49,7 +49,7 @@ export async function start({origin, hash}) {
     }
 
     else if (pragma(/^► see (\w+) plugin$/)) {
-      let plugin = types[m[1]]
+      let plugin = plugins[m[1]]
       confirm(plugin && !plugin.err, plugin && plugin.err)
     }
 


### PR DESCRIPTION
We no longer redundantly load plugins. See test.log below.

We also normalize some terminology:
- dynaload => load
- types[] => plugins[]

We've also made load responsible for updating plugins[]

![image](https://user-images.githubusercontent.com/12127/118742443-42344080-b805-11eb-9e23-eccfcb60eccc.png)
