### PR TITLE
click resolved with reference context

### DIFF
--- a/samples/headless/plugins/wiki-client-type-reference.js
+++ b/samples/headless/plugins/wiki-client-type-reference.js
@@ -1,0 +1,24 @@
+// Smallest plugin for reference
+
+export { emit, bind }
+
+function expand(text) {
+  return text
+}
+
+function emit($item, item) {
+  let html = expand(item.text)
+  if($item && $item.innerHTML)
+    $item.innerHTML = html
+  else if ($item && $item.look) {
+    $item.look = html
+    $item.links.push(item.title) 
+    $item.context = item.site   
+  }
+  else
+    return html
+}
+
+function bind($item, item) {
+
+}


### PR DESCRIPTION
We add a Reference plugin and support its distinctive behavior.
- expose the link implicit without mention in the text
- expose the site as additional resolution context
- extend the type:click event to include item.id where click occurs

We also add a pragma to `► show plugins` in the plugin cache